### PR TITLE
feat(shell-config): add autocd option to zshrc

### DIFF
--- a/ultramarine/shell-config/ultramarine-shell.zsh
+++ b/ultramarine/shell-config/ultramarine-shell.zsh
@@ -23,3 +23,4 @@ HISTSIZE=10000
 SAVEHIST=10000
 setopt appendhistory
 setopt SHARE_HISTORY
+setopt autocd


### PR DESCRIPTION
`AUTO_CD` (`-J`)

If a command is issued that can’t be executed as a normal command, and the command is the name of a directory, perform the `cd` command to that directory.

(from the [_Z Shell Manual Chapter 16: Options_](https://zsh.sourceforge.io/Doc/Release/Options.html#Description-of-Options))

This is enabled by default on Arch Linux ISOs (the main distro that I know of using zsh by default).